### PR TITLE
Change deprecating commands in build push GHA

### DIFF
--- a/.github/workflows/build-push-fdb-exporter.yaml
+++ b/.github/workflows/build-push-fdb-exporter.yaml
@@ -38,7 +38,7 @@ jobs:
         id: var
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Changing from set-output command to environment file because set-output will be [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)