### PR TITLE
fix: messages scope did not exist

### DIFF
--- a/metrics/group_processes.go
+++ b/metrics/group_processes.go
@@ -29,6 +29,7 @@ func NewProcessesMetricGroup(reporter *MetricReporter) *ProcessesMetricGroup {
 	p.AddScope(parentScope, "grv_lat", "grv")
 	p.AddScope(parentScope, "commit_lat", "commit")
 	p.AddScope(parentScope, "read_lat", "read")
+	p.AddScope(parentScope, "messages", "messages")
 	return p
 }
 


### PR DESCRIPTION
Fixing fdb exporter not having messages scope: 

```
{"level":"error","error":"scope messages does not exist","time":"2024-06-02T10:14:21Z","message":"error"}
```