### PR TITLE
Fix CI job for testing

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,13 @@
+# Copyright 2024- Tigris Data, Inc.
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 3 # integration tests + cli tests + reviewpad
+    wait_for_ci: true
+coverage:
+  range: "50...75"
+
+flag_management:
+  default_rules:
+    carryforward: true

--- a/.github/workflows/build-push-fdb-exporter.yaml
+++ b/.github/workflows/build-push-fdb-exporter.yaml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USER }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.QUAY_REPO }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and push Docker images
         id: build-push-to-quay
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -7,13 +7,13 @@ on:
   workflow_call:
 
   pull_request:
-    
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -23,4 +23,4 @@ jobs:
           TEST_PARAM: "-coverprofile=coverage.out -covermode=atomic"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -24,3 +24,5 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,12 @@ build:
 clean:
 	rm -f ./fdb-exporter
 
+deps:
+	bash -x scripts/install_deps.sh
+
 fmt:
 	find . -name \*.go -not -path bin/ -exec goimports -w {} \;
 
-test:
+test: deps
 	# Set TEST_JSON_OUTPUT to -json to have a json output from the test
 	go test "${TEST_PARAM}" "./..."

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BUILD_PARAMS="-tags=release"
 
+.PHONY: all build clean fmt test
+
 all: build
 
 build:
@@ -13,4 +15,4 @@ fmt:
 
 test:
 	# Set TEST_JSON_OUTPUT to -json to have a json output from the test
-	go test "${TEST_PARAM}" ./...
+	go test "${TEST_PARAM}" "./..."

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+OS=$(uname -s)
+
+if [ "${OS}" == "Linux" ]
+then
+  sudo apt update && sudo apt install -y wget && sudo apt-get purge -y --auto-remove
+  wget https://github.com/apple/foundationdb/releases/download/7.1.7/foundationdb-clients_7.1.7-1_amd64.deb
+  sudo dpkg -i foundationdb*.deb
+fi


### PR DESCRIPTION
Also address NodeJS version deprecation in the workflows.

NOTE: the `go-test` test CI task is **_expected_** to fail after this fix! 