### PR TITLE
reset tally reporter on each tick

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/apple/foundationdb/bindings/go v0.0.0-20220521054011-a88e049b28d8
+	github.com/m3db/prometheus_client_golang v1.12.8
 	github.com/rs/zerolog v1.28.0
 	github.com/stretchr/testify v1.8.1
 	github.com/uber-go/tally v3.5.0+incompatible
@@ -13,7 +14,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/m3db/prometheus_client_golang v1.12.8 // indirect
 	github.com/m3db/prometheus_client_model v0.2.1 // indirect
 	github.com/m3db/prometheus_common v0.34.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	var wg sync.WaitGroup
-	mInfo := metrics.NewMetricReporter()
+	mInfo := metrics.NewMetricProvider()
 	defer mInfo.Close()
 
 	go mInfo.ServeHttp()

--- a/metrics/metric_provider.go
+++ b/metrics/metric_provider.go
@@ -15,149 +15,54 @@
 package metrics
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"time"
 
-	"github.com/tigrisdata/fdb-exporter/db"
-
-	"github.com/tigrisdata/fdb-exporter/models"
 	ulog "github.com/tigrisdata/fdb-exporter/util/log"
-	"github.com/uber-go/tally"
-	promreporter "github.com/uber-go/tally/prometheus"
 )
 
-const (
-	RelativeJsonFileLocation = "test/data"
-	DefaultListenAddress     = ":8080"
-)
-
-// High level type that can report all the metrics.
-// Reponsible for:
-// * getting the status json output periodically
-// * call the GetMetrics() method of each group, which will set up the metrics in tally
-type MetricReporter struct {
-	groups   []Collectable
-	status   *models.FullStatus
-	closer   io.Closer
-	reporter promreporter.Reporter
-	scoped
+type MetricProvider struct {
+	reporter *MetricReporter
 }
 
-// Used in integration testing when the metrics are fetched from the server
-type fetchedMetric struct {
-	key   string
-	value string
-	tags  string
+func NewMetricProvider() MetricProvider {
+	mp := MetricProvider{}
+	mp.reporter = NewMetricReporter()
+	return mp
 }
 
-func NewMetricReporter() *MetricReporter {
-	m := MetricReporter{}
-	m.scopes = make(map[string]tally.Scope)
-
-	m.reporter = promreporter.NewReporter(promreporter.Options{})
-	m.scopes["root"], m.closer = tally.NewRootScope(tally.ScopeOptions{
-		Tags:           GetBaseTags(),
-		CachedReporter: m.reporter,
-		Separator:      promreporter.DefaultSeparator,
-	}, 1*time.Second)
-
-	m.AddScope(m.scopes["root"], "fdb", "fdb")
-	m.AddScope(m.scopes["fdb"], "client", "client")
-	m.AddScope(m.scopes["fdb"], "cluster", "cluster")
-	m.AddScope(m.scopes["cluster"], "workload", "workload")
-
-	// Add each impltemented group here
-	m.groups = []Collectable{
-		NewCoordinatorMetricGroup(&m),
-		NewDbStatusMetricGroup(&m),
-		NewWorkloadOperationsMetricGroup(&m),
-		NewWorkloadTransactionsMetricGroup(&m),
-		NewWorkloadKeysMetricGroup(&m),
-		NewWorkloadBytesMetricGroup(&m),
-		NewDataMetricGroup(&m),
-		NewProcessesMetricGroup(&m),
-		NewLatencyProbeMetricGroup(&m),
-		NewBackupMetricGroup(&m),
-		NewClusterMessageMetricGroup(&m),
-	}
-	return &m
-}
-
-// Periodic data collection, called from main in a goroutine
-func (m *MetricReporter) Collect() {
-	// TODO make this configurable
-	interval := 10 * time.Second
-	ticker := time.NewTicker(interval)
-
-	ulog.E(m.collectOnce())
-	for range ticker.C {
-		ulog.E(m.collectOnce())
-	}
-	defer ticker.Stop()
-}
-
-// Single data collection, fetches status, gets the metrics from each group
-func (m *MetricReporter) collectOnce() error {
-	var err error
-	m.status, err = db.GetStatus()
-	if err != nil {
-		return fmt.Errorf("failed to get status")
-	}
-
-	if len(m.groups) == 0 {
-		ulog.E(fmt.Errorf("no metric groups detected"))
-	}
-
-	for _, group := range m.groups {
-		group.GetMetrics(m.status)
-	}
-	return nil
-}
-
-// Used only in integration testing, collects metrics from a json file
-func (m *MetricReporter) collectOnceFromFile(fileName string) error {
-	// Used in testing
-	wd, err := os.Getwd()
-	if err != nil {
-		ulog.E(err)
-	}
-	testFilePath := fmt.Sprintf("%s/../%s/%s", wd, RelativeJsonFileLocation, fileName)
-	f, err := os.Open(testFilePath)
-	if err != nil {
-		ulog.E(err)
-	}
-	defer f.Close()
-	jsonBytes, err := io.ReadAll(f)
-	if err != nil {
-		ulog.E(err)
-	}
-	err = json.Unmarshal(jsonBytes, &m.status)
-	if err != nil {
-		ulog.E(err)
-	}
-
-	for _, group := range m.groups {
-		group.GetMetrics(m.status)
-	}
-	return nil
-}
-
-func (m *MetricReporter) Close() {
-	ulog.E(m.closer.Close())
-}
-
-func (m *MetricReporter) ServeHttp() {
+func (mp *MetricProvider) ServeHttp() {
 	listenAddress := os.Getenv("FDB_EXPORTER_HTTP_LISTEN_ADDR")
 	if listenAddress == "" {
 		listenAddress = DefaultListenAddress
 	}
-	err := http.ListenAndServe(listenAddress, m.reporter.HTTPHandler())
+	err := http.ListenAndServe(listenAddress, mp)
 	if err != nil {
 		ulog.E(err)
 		os.Exit(1)
 	}
+}
+
+func (mp *MetricProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	mp.reporter.reporter.HTTPHandler().ServeHTTP(w, r)
+}
+
+func (m *MetricProvider) Close() {
+	ulog.E(m.reporter.closer.Close())
+}
+
+// Periodic data collection, called from main in a goroutine
+func (mp *MetricProvider) Collect() {
+	// TODO make this configurable
+	interval := 10 * time.Second
+	ticker := time.NewTicker(interval)
+
+	ulog.E(mp.reporter.collectOnce())
+	for range ticker.C {
+		mp.reporter.Close()
+		mp.reporter = NewMetricReporter()
+		ulog.E(mp.reporter.collectOnce())
+	}
+	defer ticker.Stop()
 }

--- a/metrics/metric_reporter.go
+++ b/metrics/metric_reporter.go
@@ -1,0 +1,139 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/tigrisdata/fdb-exporter/db"
+	"github.com/tigrisdata/fdb-exporter/models"
+	ulog "github.com/tigrisdata/fdb-exporter/util/log"
+
+	"github.com/m3db/prometheus_client_golang/prometheus"
+	"github.com/uber-go/tally"
+	promreporter "github.com/uber-go/tally/prometheus"
+)
+
+const (
+	RelativeJsonFileLocation = "test/data"
+	DefaultListenAddress     = ":8080"
+)
+
+// High level type that can report all the metrics.
+// Reponsible for:
+// * getting the status json output periodically
+// * call the GetMetrics() method of each group, which will set up the metrics in tally
+type MetricReporter struct {
+	groups   []Collectable
+	status   *models.FullStatus
+	closer   io.Closer
+	reporter promreporter.Reporter
+	scoped
+}
+
+// Used in integration testing when the metrics are fetched from the server
+type fetchedMetric struct {
+	key   string
+	value string
+	tags  string
+}
+
+func NewMetricReporter() *MetricReporter {
+	m := MetricReporter{}
+	reg := prometheus.NewRegistry()
+	m.reporter = promreporter.NewReporter(promreporter.Options{Registerer: reg})
+
+	m.scopes = make(map[string]tally.Scope)
+	m.scopes["root"], m.closer = tally.NewRootScope(tally.ScopeOptions{
+		Tags:           GetBaseTags(),
+		CachedReporter: m.reporter,
+		Separator:      promreporter.DefaultSeparator,
+	}, 1*time.Second)
+
+	m.AddScope(m.scopes["root"], "fdb", "fdb")
+	m.AddScope(m.scopes["fdb"], "client", "client")
+	m.AddScope(m.scopes["fdb"], "cluster", "cluster")
+	m.AddScope(m.scopes["cluster"], "workload", "workload")
+
+	// Add each implemented group here
+	m.groups = []Collectable{
+		NewCoordinatorMetricGroup(&m),
+		NewDbStatusMetricGroup(&m),
+		NewWorkloadOperationsMetricGroup(&m),
+		NewWorkloadTransactionsMetricGroup(&m),
+		NewWorkloadKeysMetricGroup(&m),
+		NewWorkloadBytesMetricGroup(&m),
+		NewDataMetricGroup(&m),
+		NewProcessesMetricGroup(&m),
+		NewLatencyProbeMetricGroup(&m),
+		NewBackupMetricGroup(&m),
+		NewClusterMessageMetricGroup(&m),
+	}
+	return &m
+}
+
+// Single data collection, fetches status, gets the metrics from each group
+func (m *MetricReporter) collectOnce() error {
+	var err error
+	m.status, err = db.GetStatus()
+	if err != nil {
+		return fmt.Errorf("failed to get status")
+	}
+
+	if len(m.groups) == 0 {
+		ulog.E(fmt.Errorf("no metric groups detected"))
+	}
+
+	for _, group := range m.groups {
+		group.GetMetrics(m.status)
+	}
+	return nil
+}
+
+// Used only in integration testing, collects metrics from a json file
+func (m *MetricReporter) collectOnceFromFile(fileName string) error {
+	// Used in testing
+	wd, err := os.Getwd()
+	if err != nil {
+		ulog.E(err)
+	}
+	testFilePath := fmt.Sprintf("%s/../%s/%s", wd, RelativeJsonFileLocation, fileName)
+	f, err := os.Open(testFilePath)
+	if err != nil {
+		ulog.E(err)
+	}
+	defer f.Close()
+	jsonBytes, err := io.ReadAll(f)
+	if err != nil {
+		ulog.E(err)
+	}
+	err = json.Unmarshal(jsonBytes, &m.status)
+	if err != nil {
+		ulog.E(err)
+	}
+
+	for _, group := range m.groups {
+		group.GetMetrics(m.status)
+	}
+	return nil
+}
+
+func (m *MetricReporter) Close() {
+	ulog.E(m.closer.Close())
+}


### PR DESCRIPTION
currently tally reports all the metrics which existed during the exporters runtime, even if they are not updated anymore. This change reset tally each tick, causing only new metrics to be available for exporter