### PR TITLE
assign new reporter after collection

### DIFF
--- a/metrics/metric_provider.go
+++ b/metrics/metric_provider.go
@@ -60,9 +60,11 @@ func (mp *MetricProvider) Collect() {
 
 	ulog.E(mp.reporter.collectOnce())
 	for range ticker.C {
+		newReporter := NewMetricReporter()
+		ulog.E(newReporter.collectOnce())
+
 		mp.reporter.Close()
-		mp.reporter = NewMetricReporter()
-		ulog.E(mp.reporter.collectOnce())
+		mp.reporter = newReporter
 	}
 	defer ticker.Stop()
 }


### PR DESCRIPTION
currently some metrics are zero for short period of time most likely due to a race condition between collection and exporter scrape. This change assigns new reporter only after collection is finished, so it should resolve the race