### PR TITLE
add a short wait in collection loop

### DIFF
--- a/metrics/metric_provider.go
+++ b/metrics/metric_provider.go
@@ -62,6 +62,7 @@ func (mp *MetricProvider) Collect() {
 	for range ticker.C {
 		newReporter := NewMetricReporter()
 		ulog.E(newReporter.collectOnce())
+		time.Sleep(1 * time.Second) // Wait a bit before serving new tally's data (otherwise the first query will return 0)
 
 		oldReporter := mp.reporter
 		mp.reporter = newReporter


### PR DESCRIPTION
New tally returns 0 values for data if it's queries right after creation. So we wait a second before using that data