### PR TITLE
add backup range_bytes_written metric

### DIFF
--- a/metrics/group_backup.go
+++ b/metrics/group_backup.go
@@ -72,6 +72,7 @@ func (b *BackupMetricGroup) getTaggedMetrics(status *models.FullStatus) {
 		tagMetrics["is_running"] = backupTag.RunningBackup
 		tagMetrics["running_is_restorable"] = backupTag.RunningBackupIsRestorable
 		tagMetrics["last_restorable_seconds_behind"] = backupTag.LastRestorableSecondsBehind
+		tagMetrics["range_bytes_written"] = backupTag.RangeBytesWritten
 		SetMultipleGauges(taggedScope, tagMetrics, taggedBackupTags)
 	}
 }


### PR DESCRIPTION
I'm adding the `fdb_cluster_backup_tag_kv_range_bytes_written` metric for the backup. 
This metric makes it possible to track the completeness of a snapshot in progress for a backup. 

This is interesting to track how far is a oneshot backup from finishing, and how far is a continuous backup from reaching its restorable state by completing the first snapshot (the continuous backup won't be restorable until the initial snapshot is done). 

The snapshot is done when the `fdb_cluster_backup_tag_range_bytes_written` value reaches `fdb_cluster_data_total_kv_size_bytes`.
This makes it possible to clearly track how long it took for a certain backup to reach its initial snapshot/complete. 