### PR TITLE
feat: add rss_bytes memory metric for processes

### DIFF
--- a/metrics/group_processes.go
+++ b/metrics/group_processes.go
@@ -153,6 +153,7 @@ func (p *ProcessesMetricGroup) GetMetrics(status *models.FullStatus) {
 		if process.Memory != nil {
 			metrics["mem_available_bytes"] = process.Memory.AvailableBytes
 			metrics["mem_limit_bytes"] = process.Memory.LimitBytes
+			metrics["mem_rss_bytes"] = process.Memory.RssBytes
 			metrics["mem_unused_allocated_memory"] = process.Memory.UnusedAllocatedMemory
 			metrics["mem_unused_bytes"] = process.Memory.UsedBytes
 		}

--- a/models/process.go
+++ b/models/process.go
@@ -62,6 +62,7 @@ type ProcessLocality struct {
 type ProcessMemory struct {
 	AvailableBytes        int `json:"available_bytes"`
 	LimitBytes            int `json:"limit_bytes"`
+	RssBytes             int `json:"rss_bytes"`
 	UnusedAllocatedMemory int `json:"unused_allocated_memory"`
 	UsedBytes             int `json:"used_bytes"`
 }

--- a/models/process.go
+++ b/models/process.go
@@ -62,7 +62,7 @@ type ProcessLocality struct {
 type ProcessMemory struct {
 	AvailableBytes        int `json:"available_bytes"`
 	LimitBytes            int `json:"limit_bytes"`
-	RssBytes             int `json:"rss_bytes"`
+	RssBytes              int `json:"rss_bytes"`
 	UnusedAllocatedMemory int `json:"unused_allocated_memory"`
 	UsedBytes             int `json:"used_bytes"`
 }


### PR DESCRIPTION
## Summary
- Add `rss_bytes` field to `ProcessMemory` struct to capture resident memory from FoundationDB 7.1+ process status
- Export `mem_rss_bytes` metric in the processes metric group

## Test plan
- [x] `go test ./models/...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional `rss_bytes` field to status parsing and exposes it as an additional gauge, without altering existing metric names or collection flow.
> 
> **Overview**
> Adds resident-set-size memory reporting for processes by extending `ProcessMemory` with `RssBytes` (mapped from JSON `rss_bytes`) and emitting a new `mem_rss_bytes` metric alongside existing per-process memory gauges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08d62c9d917d5fa3c42677211dc4adfcce0252c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->